### PR TITLE
Fixes a bug where "delete" key on Mac keyboards failed to delete components.

### DIFF
--- a/src/com/ra4king/circuitsimulator/gui/CircuitManager.java
+++ b/src/com/ra4king/circuitsimulator/gui/CircuitManager.java
@@ -542,6 +542,8 @@ public class CircuitManager {
 				break;
 			case DELETE:
 				mayThrow(() -> circuitBoard.removeElements(selectedElementsMap.keySet()));
+			case BACK_SPACE:
+				mayThrow(() -> circuitBoard.removeElements(selectedElementsMap.keySet()));
 			case ESCAPE:
 				if(currentState == SelectingState.ELEMENT_DRAGGED) {
 					mayThrow(() -> circuitBoard.moveElements(0, 0));

--- a/src/com/ra4king/circuitsimulator/gui/CircuitManager.java
+++ b/src/com/ra4king/circuitsimulator/gui/CircuitManager.java
@@ -541,7 +541,6 @@ public class CircuitManager {
 				isShiftDown = true;
 				break;
 			case DELETE:
-				mayThrow(() -> circuitBoard.removeElements(selectedElementsMap.keySet()));
 			case BACK_SPACE:
 				mayThrow(() -> circuitBoard.removeElements(selectedElementsMap.keySet()));
 			case ESCAPE:


### PR DESCRIPTION
Source of issue: Mac keyboards map the "delete" key to backspace rather than delete.